### PR TITLE
Ally Code and Bug Fixes

### DIFF
--- a/Empire_Guide.txt
+++ b/Empire_Guide.txt
@@ -40,6 +40,7 @@ Git Command Line Cheat Sheet:
 
 
 -------- Flag Types ---------
+
 Remote Flag:
     Yellow + any
 

--- a/src/Api/Empire.Api.ts
+++ b/src/Api/Empire.Api.ts
@@ -79,7 +79,7 @@ export default class Empire {
                 // Set to processed to prevent the flag from attempting processization every tick
                 default:
 
-                    console.log("Attempted to process flag of an unhandled type.")
+                    MemoryApi.createEmpireAlertNode("Attempted to process flag of an unhandled type.", 10);
                     flag.memory.processed = true;
                     flag.memory.complete = true;
                     break;
@@ -89,7 +89,7 @@ export default class Empire {
             const roomName = flag.pos.roomName;
             if (!Memory.rooms[roomName]) {
                 const isOwnedRoom: boolean = false;
-                console.log("Initializing Room Memory for Dependent Room [" + roomName + "].");
+                MemoryApi.createEmpireAlertNode("Initializing Room Memory for Dependent Room [" + roomName + "].", 10);
                 MemoryApi.initRoomMemory(roomName, isOwnedRoom);
             }
         }
@@ -104,7 +104,7 @@ export default class Empire {
 
         // Loop over all flags, removing them and their direct memory from the game
         for (const flag of completeFlags) {
-            console.log("Removing flag [" + flag.name + "]");
+            MemoryApi.createEmpireAlertNode("Removing flag [" + flag.name + "]", 10);
             flag.remove();
             delete Memory.flags[flag.name];
         }

--- a/src/Api/Empire.Api.ts
+++ b/src/Api/Empire.Api.ts
@@ -73,6 +73,7 @@ export default class Empire {
                     else if (flag.secondaryColor === COLOR_YELLOW) {
                         EmpireHelper.processNewStimulateFlag(flag);
                     }
+                    break;
 
                 // Unhandled Flag, print warning to console
                 // Set to processed to prevent the flag from attempting processization every tick
@@ -80,6 +81,7 @@ export default class Empire {
 
                     console.log("Attempted to process flag of an unhandled type.")
                     flag.memory.processed = true;
+                    flag.memory.complete = true;
                     break;
             }
 

--- a/src/Api/Memory.Api.ts
+++ b/src/Api/Memory.Api.ts
@@ -1707,4 +1707,22 @@ export default class MemoryApi {
                 roomNames.includes(room.name)
         );
     }
+
+    /**
+     * create a message node to display as an alert
+     * @param message the message you want displayed
+     * @param expirationLimit the time you want it to be displayed for
+     */
+    public static createEmpireAlertNode(displayMessage: string, limit: number): void {
+
+        if (!Memory.empire.alertMessages) {
+            Memory.empire.alertMessages = [];
+        }
+        const messageNode: AlertMessageNode = {
+            message: displayMessage,
+            tickCreated: Game.time,
+            expirationLimit: limit
+        };
+        Memory.empire.alertMessages.push(messageNode);
+    }
 }

--- a/src/Api/Memory.Api.ts
+++ b/src/Api/Memory.Api.ts
@@ -373,7 +373,7 @@ export default class MemoryApi {
      * Get structures of a single type in a room, updating if necessary
      *
      * [Cached] Memory.rooms[room.name].structures
-     * @param room The room to check in
+     * @param roomName The room to check in
      * @param type The type of structure to retrieve
      * @param filterFunction [Optional] A function to filter by
      * @param forceUpdate [Optional] Force structures memory to be updated
@@ -609,7 +609,7 @@ export default class MemoryApi {
             );
         }
 
-        if(remoteRooms.length === 0){
+        if (remoteRooms.length === 0) {
             return [];
         }
 
@@ -646,8 +646,8 @@ export default class MemoryApi {
             // No target room provided, just return them all
             claimRooms = _.filter(Memory.rooms[room.name].claimRooms!, (roomMemory: ClaimRoomMemory) => filterFunction);
         }
-        
-        if(claimRooms.length === 0){
+
+        if (claimRooms.length === 0) {
             return [];
         }
 
@@ -688,7 +688,7 @@ export default class MemoryApi {
             );
         }
 
-        if(attackRooms.length === 0) {
+        if (attackRooms.length === 0) {
             return [];
         }
 
@@ -722,13 +722,14 @@ export default class MemoryApi {
     public static getCreepCount(room: Room, creepConst?: RoleConstant): number {
         const filterFunction = creepConst === undefined ? undefined : (c: Creep) => c.memory.role === creepConst;
 
-        // Use get active mienrs instead specifically for miners to get them out early before they die
-        if (creepConst === ROLE_MINER) {
-            return SpawnHelper.getActiveMiners(room);
-        } else {
-            // Otherwise just get the actual count of the creeps
-            return MemoryApi.getMyCreeps(room.name, filterFunction).length;
-        }
+        // Return all creeps in that role, excluding those on deaths door
+        return _.filter(MemoryApi.getMyCreeps(room.name, filterFunction),
+            (creep: Creep) => {
+                if (creep.ticksToLive) {
+                    return creep.ticksToLive > (creep.body.length * 3);
+                }
+                return false;
+            }).length;
     }
 
     /**

--- a/src/Api/Room.Api.ts
+++ b/src/Api/Room.Api.ts
@@ -429,6 +429,12 @@ export default class RoomApi {
             }
 
             const currentRoom: Room = Game.rooms[remoteRoom.roomName];
+<<<<<<< HEAD
+=======
+            if (currentRoom === undefined) {
+                continue;
+            }
+>>>>>>> bd9d433... added set rampart status
 
             if (currentRoom === undefined) {
                 // Simulate the dropping of reserve timer by the number of ticks between checks
@@ -444,6 +450,21 @@ export default class RoomApi {
                     remoteRoom.reserveTTL = 0;
                 }
             }
+        }
+    }
+
+    /**
+     * sets the ramparts status in the room to public or private
+     * @param room the room we are setting ramparts for
+     */
+    public static runSetRampartStatus(room: Room): void {
+
+        // If defcon is on in the room, set to private, otherwise, public
+        const rampartsInRoom: StructureRampart[] = MemoryApi.getStructureOfType(room.name, STRUCTURE_RAMPART) as StructureRampart[];
+        const isPublic: boolean = MemoryApi.getDefconLevel(room) > 0;
+        for (const i in rampartsInRoom) {
+            const rampart: StructureRampart = rampartsInRoom[i];
+            rampart.setPublic(isPublic);
         }
     }
 }

--- a/src/Api/Room.Api.ts
+++ b/src/Api/Room.Api.ts
@@ -429,12 +429,9 @@ export default class RoomApi {
             }
 
             const currentRoom: Room = Game.rooms[remoteRoom.roomName];
-<<<<<<< HEAD
-=======
             if (currentRoom === undefined) {
                 continue;
             }
->>>>>>> bd9d433... added set rampart status
 
             if (currentRoom === undefined) {
                 // Simulate the dropping of reserve timer by the number of ticks between checks

--- a/src/Api/Spawn.Api.ts
+++ b/src/Api/Spawn.Api.ts
@@ -95,7 +95,7 @@ export default class SpawnApi {
                 // Domestic Creep Definitions
                 domesticLimits[ROLE_MINER] = minerLimits;
                 domesticLimits[ROLE_HARVESTER] = 3;
-                domesticLimits[ROLE_WORKER] = 5;
+                domesticLimits[ROLE_WORKER] = 4;
 
                 break;
 

--- a/src/Helpers/EmpireHelper.ts
+++ b/src/Helpers/EmpireHelper.ts
@@ -11,6 +11,7 @@ import {
     ERROR_WARN,
     STIMULATE_FLAG
 } from "utils/Constants";
+import RoomVisualHelper from "Managers/RoomVisuals/RoomVisualHelper";
 
 export default class EmpireHelper {
 
@@ -65,7 +66,7 @@ export default class EmpireHelper {
             reserveTTL: 0,
         };
 
-        console.log("Remote Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]");
+        MemoryApi.createEmpireAlertNode("Remote Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]", 10);
         dependentRoom.memory.remoteRooms!.push(remoteRoomMemory);
     }
 
@@ -99,7 +100,7 @@ export default class EmpireHelper {
             });
 
         if (existingDepedentAttackRoomMem) {
-            console.log("Attack Flag [" + flag.name + "] processed. Added to existing Host Room: [" + existingDepedentAttackRoomMem.roomName + "]");
+            MemoryApi.createEmpireAlertNode("Attack Flag [" + flag.name + "] processed. Added to existing Host Room: [" + existingDepedentAttackRoomMem.roomName + "]", 10);
             existingDepedentAttackRoomMem.flags.push(attackFlagMemory);
             return;
         }
@@ -112,7 +113,7 @@ export default class EmpireHelper {
             flags: [attackFlagMemory],
         };
 
-        console.log("Attack Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]");
+        MemoryApi.createEmpireAlertNode("Attack Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]", 10);
         dependentRoom.memory.attackRooms!.push(attackRoomMemory);
     }
 
@@ -163,7 +164,7 @@ export default class EmpireHelper {
             flags: [claimFlagMemory],
         };
 
-        console.log("Claim Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]");
+        MemoryApi.createEmpireAlertNode("Claim Flag [" + flag.name + "] processed. Host Room: [" + dependentRoom.name + "]", 10);
         dependentRoom.memory.claimRooms!.push(claimRoomMemory);
     }
 
@@ -181,7 +182,7 @@ export default class EmpireHelper {
         Memory.flags[flag.name].flagType = flagTypeConst;
         Memory.flags[flag.name].flagName = flag.name;
 
-        console.log("Option Flag [" + flag.name + "] processed. Flag Type: [" + flagTypeConst + "]");
+        MemoryApi.createEmpireAlertNode("Option Flag [" + flag.name + "] processed. Flag Type: [" + RoomVisualHelper.convertFlagTypeToString(flagTypeConst) + "]", 10);
     }
 
     /**
@@ -198,7 +199,7 @@ export default class EmpireHelper {
         Memory.flags[flag.name].flagType = flagTypeConst;
         Memory.flags[flag.name].flagName = flag.name;
 
-        console.log("Option Flag [" + flag.name + "] processed. Flag Type: [" + flagTypeConst + "]");
+        MemoryApi.createEmpireAlertNode("Option Flag [" + flag.name + "] processed. Flag Type: [" + RoomVisualHelper.convertFlagTypeToString(flagTypeConst) + "]", 10);
     }
 
     /**
@@ -328,7 +329,7 @@ export default class EmpireHelper {
             const claimRoomName: string = claimRooms[claimRoom]!.roomName;
 
             if (!claimRooms[claimRoom]!.flags[0]) {
-                console.log("Removing Claim Room [" + claimRooms[claimRoom]!.roomName + "]");
+                MemoryApi.createEmpireAlertNode("Removing Claim Room [" + claimRooms[claimRoom]!.roomName + "]", 10);
 
                 // Get the dependent room for the attack room we are removing from memory
                 const dependentRoom: Room | undefined = _.find(MemoryApi.getOwnedRooms(),
@@ -368,7 +369,7 @@ export default class EmpireHelper {
                 // Tell typescript that these are claim flag memory structures
                 const currentFlag: ClaimFlagMemory = claimRoom!.flags[flag] as ClaimFlagMemory;
                 if (!Game.flags[currentFlag.flagName]) {
-                    console.log("Removing [" + flag + "] from Claim Room [" + claimRoom!.roomName + "]");
+                    MemoryApi.createEmpireAlertNode("Removing [" + flag + "] from Claim Room [" + claimRoom!.roomName + "]", 10);
                     delete claimRoom!.flags[flag];
                 }
             }
@@ -389,7 +390,7 @@ export default class EmpireHelper {
             const attackRoomName: string = attackRooms[attackRoom]!.roomName;
 
             if (!attackRooms[attackRoom]!.flags[0]) {
-                console.log("Removing Attack Room [" + attackRooms[attackRoom]!.roomName + "]");
+                MemoryApi.createEmpireAlertNode("Removing Attack Room [" + attackRooms[attackRoom]!.roomName + "]", 10);
 
                 // Get the dependent room for the attack room we are removing from memory
                 const dependentRoom: Room | undefined = _.find(MemoryApi.getOwnedRooms(),
@@ -428,7 +429,7 @@ export default class EmpireHelper {
                 // Tell typescript that these are claim flag memory structures
                 const currentFlag: AttackFlagMemory = attackRoom!.flags[flag] as AttackFlagMemory;
                 if (!Game.flags[currentFlag.flagName]) {
-                    console.log("Removing [" + flag + "] from Attack Room [" + attackRoom!.roomName + "]");
+                    MemoryApi.createEmpireAlertNode("Removing [" + flag + "] from Attack Room [" + attackRoom!.roomName + "]", 10);
                     delete attackRoom!.flags[flag];;
                 }
             }
@@ -449,7 +450,7 @@ export default class EmpireHelper {
             const remoteRoomName: string = remoteRooms[remoteRoom]!.roomName;
 
             if (!remoteRooms[remoteRoom]!.flags[0]) {
-                console.log("Removing Remote Room [" + remoteRooms[remoteRoom]!.roomName + "]");
+                MemoryApi.createEmpireAlertNode("Removing Remote Room [" + remoteRooms[remoteRoom]!.roomName + "]", 10);
 
                 // Get the dependent room for this room
                 const dependentRoom: Room | undefined = _.find(MemoryApi.getOwnedRooms(),
@@ -489,7 +490,7 @@ export default class EmpireHelper {
                 // Tell typescript that these are claim flag memory structures
                 const currentFlag: RemoteFlagMemory = remoteRoom!.flags[flag] as RemoteFlagMemory;
                 if (!Game.flags[currentFlag.flagName]) {
-                    console.log("Removing [" + flag + "] from Remote Room Memory [" + remoteRoom!.roomName + "]");
+                    MemoryApi.createEmpireAlertNode("Removing [" + flag + "] from Remote Room Memory [" + remoteRoom!.roomName + "]", 10);
                     delete remoteRoom!.flags[flag];
                 }
             }

--- a/src/Helpers/EmpireHelper.ts
+++ b/src/Helpers/EmpireHelper.ts
@@ -197,6 +197,8 @@ export default class EmpireHelper {
         Memory.flags[flag.name].timePlaced = Game.time;
         Memory.flags[flag.name].flagType = flagTypeConst;
         Memory.flags[flag.name].flagName = flag.name;
+
+        console.log("Option Flag [" + flag.name + "] processed. Flag Type: [" + flagTypeConst + "]");
     }
 
     /**

--- a/src/Helpers/MemoryHelper_Room.ts
+++ b/src/Helpers/MemoryHelper_Room.ts
@@ -65,13 +65,13 @@ export default class MemoryHelper_Room {
             return;
         }
 
-        Memory.rooms[roomName].hostiles = { data: { ranged: [], melee: [], heal: [], boosted: [] }, cache: null };
         const enemies = Game.rooms[roomName].find(FIND_HOSTILE_CREEPS, {
             filter:
-                (creep: Creep) => MiliHelper.isAllyCreep(creep)
+                (creep: Creep) => !MiliHelper.isAllyCreep(creep)
         });
 
         // Sort creeps into categories
+        Memory.rooms[roomName].hostiles = { data: { ranged: [], melee: [], heal: [], boosted: [], civilian: [] }, cache: null };
         _.forEach(enemies, (enemy: Creep) => {
             // * Check for boosted creeps and put them at the front of the if else stack
             if (enemy.getActiveBodyparts(HEAL) > 0) {
@@ -80,9 +80,10 @@ export default class MemoryHelper_Room {
                 Memory.rooms[roomName].hostiles.data.ranged.push(enemy.id);
             } else if (enemy.getActiveBodyparts(ATTACK) > 0) {
                 Memory.rooms[roomName].hostiles.data.melee.push(enemy.id);
+            } else {
+                Memory.rooms[roomName].hostiles.data.civilian.push(enemy.id);
             }
         });
-
         Memory.rooms[roomName].hostiles.cache = Game.time;
     }
 

--- a/src/Helpers/RoomHelper.ts
+++ b/src/Helpers/RoomHelper.ts
@@ -265,6 +265,11 @@ export default class RoomHelper {
             _.some(c.body, (b: BodyPartDefinition) => b.type === "attack" || b.type === "ranged_attack"));
         const isWorkers: boolean = _.some(hostileCreeps, (c: Creep) =>
             _.some(c.body, (b: BodyPartDefinition) => b.type === "work"));
+        const isCivilians: boolean = _.some(hostileCreeps, (creep: Creep) =>
+            !_.some(creep.body, (b: BodyPartDefinition) => b.type === "heal") &&
+            !_.some(creep.body, (b: BodyPartDefinition) => b.type === "attack" || b.type === "ranged_attack") &&
+            !_.some(creep.body, (b: BodyPartDefinition) => b.type === "work")
+        );
 
         // If only healers are present, don't waste ammo
         if (isHealers && !isAttackers && !isWorkers) {
@@ -287,6 +292,15 @@ export default class RoomHelper {
         if (isAttackers) {
             return _.find(hostileCreeps, (c: Creep) =>
                 _.some(c.body, (b: BodyPartDefinition) => b.type === "attack"));
+        }
+
+        // If no combat related creeps, target civilians
+        if (isCivilians) {
+            _.find(hostileCreeps, (creep: Creep) =>
+                !_.some(creep.body, (b: BodyPartDefinition) => b.type === "heal") &&
+                !_.some(creep.body, (b: BodyPartDefinition) => b.type === "attack" || b.type === "ranged_attack") &&
+                !_.some(creep.body, (b: BodyPartDefinition) => b.type === "work")
+            );
         }
 
         // If there are no hostile creeps, or we didn't find a valid target, return undefined

--- a/src/Helpers/SpawnHelper.ts
+++ b/src/Helpers/SpawnHelper.ts
@@ -1252,19 +1252,6 @@ export class SpawnHelper {
     }
 
     /**
-     * Returns the number of miners that are not spawning, and have > 50 ticksToLive
-     * @param room the room we are checking in
-     */
-    public static getActiveMiners(room: Room): number {
-        let miners = MemoryHelper.getCreepOfRole(room, ROLE_MINER);
-        miners = _.filter(miners, (creep: Creep) => {
-            // False if miner is spawning or has less than 50 ticks to live
-            return !creep.spawning && creep.ticksToLive! > 50;
-        });
-        return miners.length;
-    }
-
-    /**
      * gets the ClaimRoomMemory with lowest number creeps of the specified role with it as their target room
      * Must also be less than the max amount of that role allowed for the room
      * @param room the room spawning the creep

--- a/src/Managers/MemoryManagement.ts
+++ b/src/Managers/MemoryManagement.ts
@@ -43,5 +43,9 @@ export default class MemoryManager {
         if (!Memory.creeps) {
             Memory.creeps = {};
         }
+
+        if (!Memory.empire) {
+            Memory.empire = {};
+        }
     }
 }

--- a/src/Managers/RoomManager.ts
+++ b/src/Managers/RoomManager.ts
@@ -9,6 +9,7 @@ import {
     RUN_ROOM_STATE_TIMER,
     RUN_DEFCON_TIMER,
     RUN_RESERVE_TTL_TIMER,
+    RUN_RAMPART_STATUS_UPDATE,
 } from "utils/config";
 
 // room-wide manager
@@ -74,6 +75,11 @@ export default class RoomManager {
             RoomApi.runTerminal(room);
         }
 
+        // Set Rampart access status
+        if (RoomHelper.isExistInRoom(room, STRUCTURE_RAMPART) &&
+            RoomHelper.excecuteEveryTicks(RUN_RAMPART_STATUS_UPDATE)) {
+            RoomApi.runSetRampartStatus(room);
+        }
         // Run accessory functions for dependent rooms ----
         // Update reserve timer for remote rooms
         if (RoomHelper.excecuteEveryTicks(RUN_RESERVE_TTL_TIMER)) {

--- a/src/Managers/RoomVisuals/RoomVisual.Api.ts
+++ b/src/Managers/RoomVisuals/RoomVisual.Api.ts
@@ -190,7 +190,7 @@ export default class RoomVisualApi {
         // Adding this disclaimer, beacuse some of the information you need is actually calculated in the graph function
         // Consider decoupling these so you could use them independently
         if (ROOM_OVERLAY_GRAPH_ON) {
-            // ! Disabled due to error in calculations. 
+            // ! Disabled due to error in calculations.
             // TODO Fix this function
             // lines.push("Est TTL:        " + RoomVisualHelper.getEstimatedTimeToNextLevel(room));
         }
@@ -353,10 +353,9 @@ export default class RoomVisualApi {
      */
     public static createOptionFlagVisual(room: Room, x: number, y: number): number {
 
-        const optionFlags = _.filter(Memory.flags, (flag: FlagMemory) =>
-            flag.flagType ===
-            (OVERRIDE_D_ROOM_FLAG || STIMULATE_FLAG) &&
-            (Game.flags[flag.flagName].pos.roomName === room.name)
+        const allFlagsMemory: FlagMemory[] = _.map(Game.flags, (flag: Flag) => flag.memory);
+        const optionFlags: FlagMemory[] = _.filter(allFlagsMemory,
+            (flag: FlagMemory) => (flag.flagType === OVERRIDE_D_ROOM_FLAG) || flag.flagType === STIMULATE_FLAG
         );
 
         // Draw the text
@@ -364,13 +363,13 @@ export default class RoomVisualApi {
         lines.push("");
         lines.push("Option Flags ")
         lines.push("");
-        for (const of of optionFlags) {
-            if (!of) {
+        for (const optionFlag in optionFlags) {
+            if (!optionFlags[optionFlag]) {
                 continue;
             }
 
-            lines.push("Flag:   [ " + of.flagName + " ] ");
-            lines.push("Type:   [ " + of.flagType + " ] ");
+            lines.push("Flag:   [ " + optionFlags[optionFlag].flagName + " ] ");
+            lines.push("Type:   [ " + RoomVisualHelper.convertFlagTypeToString(optionFlags[optionFlag].flagType) + " ] ");
             lines.push("");
         }
 

--- a/src/Managers/RoomVisuals/RoomVisual.Api.ts
+++ b/src/Managers/RoomVisuals/RoomVisual.Api.ts
@@ -491,4 +491,60 @@ export default class RoomVisualApi {
             startCoord = endCoord;
         }
     }
+
+    /**
+     * display messages and handle managing the data structure that holds him
+     * @param room the room we are creating the visual for
+     * @param x the x value for the visual
+     * @param y the y value for the visual
+     */
+    public static createMessageBoxVisual(room: Room, x: number, y: number): number {
+
+        // Make sure the message structure exists in memory
+        if (!Memory.empire.alertMessages) {
+            Memory.empire.alertMessages = [];
+        }
+
+        // Draw the title
+        const lines: string[] = [];
+        lines.push("");
+        lines.push("Alerts ")
+        lines.push("");
+
+        // Remove expired messages and add valid messages to the lines array
+        const newArray: AlertMessageNode[] = [];
+        let largestMessage: number = 0;
+        for (const i in Memory.empire.alertMessages) {
+            const messageNode: AlertMessageNode = Memory.empire.alertMessages[i];
+            const currentTick: number = Game.time;
+
+            if (!(currentTick - messageNode.tickCreated >= messageNode.expirationLimit)) {
+                newArray.push(messageNode);
+                lines.push(messageNode.message);
+                largestMessage = largestMessage < messageNode.message.length ? messageNode.message.length : largestMessage;
+            }
+        }
+        Memory.empire.alertMessages = newArray;
+
+        // If no remote rooms, print none
+        if (lines.length === 3) {
+            lines.push("No Current Alerts ");
+            lines.push("");
+        }
+        else {
+            lines.push("");
+        }
+        RoomVisualHelper.multiLineText(lines, x, y, room.name, false);
+
+        // Draw the box around the text
+        largestMessage = (largestMessage / 3) < 10 ? 10 : (largestMessage / 3);
+        new RoomVisual(room.name)
+            .line(x - largestMessage, y + lines.length - 1, x + .25, y + lines.length - 1)    // bottom line
+            .line(x - largestMessage, y - 1, x + .25, y - 1)                  // top line
+            .line(x - largestMessage, y - 1, x - largestMessage, y + lines.length - 1)   // left line
+            .line(x + .25, y - 1, x + .25, y + lines.length - 1);  // right line
+
+        // Return where the next box should start
+        return y + lines.length;
+    }
 }

--- a/src/Managers/RoomVisuals/RoomVisual.Api.ts
+++ b/src/Managers/RoomVisuals/RoomVisual.Api.ts
@@ -521,6 +521,7 @@ export default class RoomVisualApi {
             if (!(currentTick - messageNode.tickCreated >= messageNode.expirationLimit)) {
                 newArray.push(messageNode);
                 lines.push(messageNode.message);
+                lines.push("");
                 largestMessage = largestMessage < messageNode.message.length ? messageNode.message.length : largestMessage;
             }
         }
@@ -529,9 +530,6 @@ export default class RoomVisualApi {
         // If no remote rooms, print none
         if (lines.length === 3) {
             lines.push("No Current Alerts ");
-            lines.push("");
-        }
-        else {
             lines.push("");
         }
         RoomVisualHelper.multiLineText(lines, x, y, room.name, false);

--- a/src/Managers/RoomVisuals/RoomVisualHelper.ts
+++ b/src/Managers/RoomVisuals/RoomVisualHelper.ts
@@ -8,7 +8,11 @@ import {
     ROOM_STATE_UPGRADER,
     STANDARD_SQUAD,
     ZEALOT_SOLO,
-    STALKER_SOLO
+    STALKER_SOLO,
+    CLAIM_FLAG,
+    REMOTE_FLAG,
+    OVERRIDE_D_ROOM_FLAG,
+    STIMULATE_FLAG
 } from "utils/constants";
 import RoomHelper from "Helpers/RoomHelper";
 
@@ -90,8 +94,16 @@ export default class RoomVisualManager {
                 return "Stalker Solo";
             case ZEALOT_SOLO:
                 return "Zealot Solo";
+            case CLAIM_FLAG:
+                return "Claim";
+            case REMOTE_FLAG:
+                return "Remote";
+            case OVERRIDE_D_ROOM_FLAG:
+                return "Dependent Room Override";
+            case STIMULATE_FLAG:
+                return "Stimulate";
             default:
-                return "Not An Attack Flag";
+                return "Not a valid flag type (roomVisualHelper/convertFlagTypeToString).";
         }
     }
 
@@ -136,7 +148,7 @@ export default class RoomVisualManager {
                 avgControlPointsPerHourArray: [],
                 room: {},
                 etaMemory: { rcl: room.controller!.level, avgPointsPerTick: 0, ticksMeasured: 0 }
-            } as VisualMemory; 
+            } as VisualMemory;
         }
 
         const progressSampleSize: number = Memory.rooms[room.name].visual!.controllerProgressArray.length;

--- a/src/Managers/RoomVisuals/RoomVisualHelper.ts
+++ b/src/Managers/RoomVisuals/RoomVisualHelper.ts
@@ -99,7 +99,7 @@ export default class RoomVisualManager {
             case REMOTE_FLAG:
                 return "Remote";
             case OVERRIDE_D_ROOM_FLAG:
-                return "Dependent Room Override";
+                return "Override";
             case STIMULATE_FLAG:
                 return "Stimulate";
             default:

--- a/src/Managers/RoomVisuals/RoomVisualManager.ts
+++ b/src/Managers/RoomVisuals/RoomVisualManager.ts
@@ -58,5 +58,7 @@ export default class RoomVisualManager {
         endRightLine = RoomVisualApi.createAttackFlagVisual(room, RIGHT_START_X, endRightLine);
         // Display Option Flag box on the bottom right
         endRightLine = RoomVisualApi.createOptionFlagVisual(room, RIGHT_START_X, endRightLine);
+        // Display message box on the bottom right
+        endRightLine = RoomVisualApi.createMessageBoxVisual(room, RIGHT_START_X, endRightLine);
     }
 }

--- a/src/Managers/SpawnManager.ts
+++ b/src/Managers/SpawnManager.ts
@@ -1,5 +1,6 @@
 import SpawnApi from "../Api/Spawn.Api";
 import MemoryApi from "../Api/Memory.Api";
+import { TIER_2 } from "../utils/constants";
 
 // handles spawning for every room
 export default class SpawnManager {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,12 +83,6 @@
  * 2. UpgraderLink does not set itself in room memory - It should choose the one closest to spawn
  *          To be more useable, it should also reset if there is a closer link placed. This follows our rule of not forcing a gameplay style.
  *
- * 6. Option flags throw an error regardless if they are processed or not
- * Place an option flag to recreate
- *
- * 7. Stimulate flags don't process at all
- * Place a stimulate flag to recreate
- *
  * 8. Towers do not fire the last shot to kill invaders, only seen this happen once
  * To recreate, spawn a big boosted invader and the tower will stop on the final attack
  * and the defcon level will go down. This is most likely related to how we are getting the defcon level
@@ -97,8 +91,6 @@
  *
  * 8. Even worse, just had an invasion and my targets didn't even fire once. Either defcon isn't getting set properly or they aren't finding their target properly.
  * Not sure how to recreate, as they seem to respond to invasions, but it happens frequently enough where i lost 200 creep parts in last 24 hours
- *
- * 9. Multiple Spawns are not being handled correctly - Will duplicate creeps - e.g. I had 3 miners when limit was 2
  *
  */
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@
  * TODO Complete Remote Job Creation - Need to get the rooms that need something done
  *
  * 1. Migrate some of the getJob functions from CreepManagers to Creep.Api to make code accessible by other CreepManagers
- * 
+ *
  * 2. Complete Remote Miner
  * We want the remote miner to go to a source and mine it, build a container and his feet, and build/repair it during his down time.
  * We should also give remote miners 7 work parts imo. 6 wasn't enough to keep the container repaired and it was slow on building it
@@ -69,11 +69,6 @@
  * Also make the system that spawns more workers in the case of remote rooms more reliable and cleanly coded (combine these systems preferrably)
  * into a function like getExtraWorkerAmount: number and add to the base amount of workers for that room state
  *
- * 14. Expand tower targeting to target non-combat creeps if no other targets are found, we might as well snipe out scouts
- * Still do not target solo healers (maybe consider it if we calculate our damage (we have a function for that, thanks bonzai)
- * and find that we can out damage the amount of healing on a creep and those around it)
- *
- *
  * ~~~~~~~~~~~~~~~~
  * ~~ BUG FIXES ~~
  * ~~~~~~~~~~~~~~~~
@@ -82,15 +77,6 @@
  *
  * 2. UpgraderLink does not set itself in room memory - It should choose the one closest to spawn
  *          To be more useable, it should also reset if there is a closer link placed. This follows our rule of not forcing a gameplay style.
- *
- * 8. Towers do not fire the last shot to kill invaders, only seen this happen once
- * To recreate, spawn a big boosted invader and the tower will stop on the final attack
- * and the defcon level will go down. This is most likely related to how we are getting the defcon level
- * because towers won't even attempt to target anything if the defcon level is 0
- * So start by looking in how we're getting defcon and make sure we keep it that level until every creep is dead
- *
- * 8. Even worse, just had an invasion and my targets didn't even fire once. Either defcon isn't getting set properly or they aren't finding their target properly.
- * Not sure how to recreate, as they seem to respond to invasions, but it happens frequently enough where i lost 200 creep parts in last 24 hours
  *
  */
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -614,7 +614,33 @@ interface RoomMemory {
     visual?: VisualMemory;
 }
 
-interface EmpireMemory { }
+interface Memory {
+    empire: EmpireMemory
+}
+interface EmpireMemory {
+    /**
+     * messages to display in each room's alert box
+     */
+    alertMessages?: AlertMessageNode[];
+}
+
+/**
+ * a node for an alert message
+ */
+interface AlertMessageNode {
+    /**
+     * the message
+     */
+    message: string;
+    /**
+     * tick that it was created on
+     */
+    tickCreated: number;
+    /**
+     * the number of ticks you want the message to be shown
+     */
+    expirationLimit: number;
+}
 // ----------------------------------
 
 /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -93,6 +93,7 @@ export const RUN_TERMINAL_TIMER = 5;
 export const RUN_ROOM_STATE_TIMER = 5;
 export const RUN_DEFCON_TIMER = 2;
 export const RUN_RESERVE_TTL_TIMER = 1;
+export const RUN_RAMPART_STATUS_UPDATE = 1;
 export const RESERVER_MIN_TTL = 500;
 
 /**


### PR DESCRIPTION
Made ramparts public when not under defcon lockdown (so allies can travel through)

Fixed option flags not processing, and fixed them to show up in room overlay

Enhanced tower targeting, and added non-combat creeps into getHostiles

Enhanced getCreepCount to not include creeps who's TTL is less than (bodyPartCount * 3)
removed previous implementation of this, which incidentally was causing the multi-spawn bug i think

squashed commits and rebased dev